### PR TITLE
Added option to choose type of phi initialization

### DIFF
--- a/Image/Image.cpp
+++ b/Image/Image.cpp
@@ -56,7 +56,7 @@ void Image::initFimage()
 		}
 }
 
-void Image::initPhi()
+void Image::initPhi(int type)
 {
 	phi= new float*[rows];
 	for(int i = 0; i < rows; ++i)
@@ -65,6 +65,9 @@ void Image::initPhi()
 	for (std::size_t i = 0; i < rows; ++i)
        		for (std::size_t j = 0; j < cols; ++j)
        		{
+                    if (type == 1)
+                        phi[i][j] = sin( M_PI *i/5)*sin( M_PI *j/5);
+                    if (type == 2)
         		phi[i][j] = 100 - sqrt( (rows/2-i)*(rows/2-i) + (cols/2-j)*(cols/2-j) ); 
 			//Middle point of a circle depends on image size 
     			//phi[i][j] = Heaviside(phi[i][j]);

--- a/Image/Image.hpp
+++ b/Image/Image.hpp
@@ -43,7 +43,7 @@ private:
 	
 	void initImage(const std::string& filename, int flags);
 	void initFimage(); 
-	void initPhi();
+	void initPhi(int type = 1);    //default sinus initialization, 2 <- circle
 	void destroyFimage();
 	void destroyPhi();
 	float Heaviside(float data);


### PR DESCRIPTION
Issue #14 
For now, default initialization is set as type = 1, that is as sinus. But that option doesn't work properly (probably because of bad parameter's value; the same situation as in issue #17 ).
In order to change default init from sinus to circle, in Image.hpp file line 46 have to be changed
from "void initPhi(int type = 1);"
to "void initPhi(int type = 2);"